### PR TITLE
Support multiple databases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixpoints (0.1.2)
+    fixpoints (0.2.0)
       activerecord (>= 5.0.0)
       rspec
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ RSpec.describe 'User Flow', order: :defined do # !!! mind the order here !!!
     fill_in 'Name', with: 'Tom'
     click_on 'Save'
 
-    store_fixpoint_unless_present :registred_user
+    store_fixpoint_unless_present :registered_user
     # creates a YAML file containing all records (/spec/fixpoints/registred_user.yml)
   end
 
@@ -113,6 +113,15 @@ In order to achieve this, we must make sure that we let the store function know 
   end
 ```
 
+**Multiple Databases** If an application uses multiple databases, you can use the optional `connection` parameter
+to specify the database connection to use.
+
+```ruby
+  it 'posts an item' do
+    restore_fixpoint :registered_user, connection: ActiveRecord::Base.connection
+    # ...
+  end
+```
 
 ## Limitations & Known issues
 

--- a/lib/fixpoint.rb
+++ b/lib/fixpoint.rb
@@ -87,7 +87,7 @@ class Fixpoint
       tables.reject! { |table_name| TABLES_TO_SKIP.include?(table_name) }
 
       tables.each_with_object({}) do |table_name, acc|
-        result = conn.select_all("SELECT * FROM #{table_name}")
+        result = conn.select_all("SELECT * FROM #{conn.quote_table_name(table_name)}")
         next if result.count.zero?
 
         rows = result.to_a

--- a/lib/fixpoint_test_helpers.rb
+++ b/lib/fixpoint_test_helpers.rb
@@ -1,8 +1,8 @@
 # Helper methods to be included into RSpec
 module FixpointTestHelpers
-  def restore_fixpoint(fixname, base: ActiveRecord::Base)
+  def restore_fixpoint(fixname, connection: default_connection)
     @last_restored = fixname
-    IncrementalFixpoint.from_file(fixname).load_into_database(base.connection)
+    IncrementalFixpoint.from_file(fixname).load_into_database(connection)
   end
 
   # Compares the fixpoint with the records in the database.
@@ -16,10 +16,10 @@ module FixpointTestHelpers
   # ---
   # If we refactor this to a gem, we should rely on rspec (e.g. use minitest or move comparison logic to Fixpoint class).
   # Anyhow, we keep it like this for now, because the expectations give much nicer output than the minitest assertions.
-  def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, store_fixpoint_and_fail: false, parent_fixname: nil, base: ActiveRecord::Base)
+  def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, store_fixpoint_and_fail: false, parent_fixname: nil, connection: default_connection)
     if !IncrementalFixpoint.exists?(fixname)
       if store_fixpoint_and_fail
-        store_fixpoint(fixname, parent_fixname)
+        store_fixpoint(fixname, parent_fixname, connection: connection)
         pending("Fixpoint \"#{fixname}\" did not exist yet. Skipping comparison, but created fixpoint from database. Try re-running the test.")
         fail
       else
@@ -27,7 +27,7 @@ module FixpointTestHelpers
       end
     end
 
-    database_fp = IncrementalFixpoint.from_database(nil, base.connection)
+    database_fp = IncrementalFixpoint.from_database(nil, connection)
     fixpoint_fp = IncrementalFixpoint.from_file(fixname)
 
     tables_to_compare = (database_fp.table_names + fixpoint_fp.table_names).uniq if tables_to_compare == :all
@@ -45,14 +45,18 @@ module FixpointTestHelpers
 
   # it is not a good idea to overwrite the fixpoint each time because timestamps may change (which then shows up in version control).
   # Hence we only provide a method to write to it if it does not exist.
-  def store_fixpoint_unless_present(fixname, parent_fixname = nil, base: ActiveRecord::Base)
-    store_fixpoint(fixname, parent_fixname, base: base) unless IncrementalFixpoint.exists?(fixname)
+  def store_fixpoint_unless_present(fixname, parent_fixname = nil, connection: default_connection)
+    store_fixpoint(fixname, parent_fixname, connection: connection) unless IncrementalFixpoint.exists?(fixname)
   end
 
   # +parent_fixname+ when given, only the (incremental) changes to the parent are saved
   # please see store_fixpoint_unless_present for note on why not to use this method
-  def store_fixpoint(fixname, parent_fixname = nil, base: ActiveRecord::Base)
+  def store_fixpoint(fixname, parent_fixname = nil, connection: default_connection)
     parent_fixname = @last_restored if parent_fixname == :last_restored
-    IncrementalFixpoint.from_database(parent_fixname, base.connection).save_to_file(fixname)
+    IncrementalFixpoint.from_database(parent_fixname, connection).save_to_file(fixname)
+  end
+
+  private def default_connection
+    ActiveRecord::Base.connection
   end
 end

--- a/lib/fixpoint_test_helpers.rb
+++ b/lib/fixpoint_test_helpers.rb
@@ -1,8 +1,8 @@
 # Helper methods to be included into RSpec
 module FixpointTestHelpers
-  def restore_fixpoint(fixname)
+  def restore_fixpoint(fixname, base: ActiveRecord::Base)
     @last_restored = fixname
-    IncrementalFixpoint.from_file(fixname).load_into_database
+    IncrementalFixpoint.from_file(fixname).load_into_database(base.connection)
   end
 
   # Compares the fixpoint with the records in the database.
@@ -16,7 +16,7 @@ module FixpointTestHelpers
   # ---
   # If we refactor this to a gem, we should rely on rspec (e.g. use minitest or move comparison logic to Fixpoint class).
   # Anyhow, we keep it like this for now, because the expectations give much nicer output than the minitest assertions.
-  def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, store_fixpoint_and_fail: false, parent_fixname: nil)
+  def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, store_fixpoint_and_fail: false, parent_fixname: nil, base: ActiveRecord::Base)
     if !IncrementalFixpoint.exists?(fixname)
       if store_fixpoint_and_fail
         store_fixpoint(fixname, parent_fixname)
@@ -27,7 +27,7 @@ module FixpointTestHelpers
       end
     end
 
-    database_fp = IncrementalFixpoint.from_database
+    database_fp = IncrementalFixpoint.from_database(nil, base.connection)
     fixpoint_fp = IncrementalFixpoint.from_file(fixname)
 
     tables_to_compare = (database_fp.table_names + fixpoint_fp.table_names).uniq if tables_to_compare == :all
@@ -45,14 +45,14 @@ module FixpointTestHelpers
 
   # it is not a good idea to overwrite the fixpoint each time because timestamps may change (which then shows up in version control).
   # Hence we only provide a method to write to it if it does not exist.
-  def store_fixpoint_unless_present(fixname, parent_fixname = nil)
-    store_fixpoint(fixname, parent_fixname) unless IncrementalFixpoint.exists?(fixname)
+  def store_fixpoint_unless_present(fixname, parent_fixname = nil, base: ActiveRecord::Base)
+    store_fixpoint(fixname, parent_fixname, base: base) unless IncrementalFixpoint.exists?(fixname)
   end
 
   # +parent_fixname+ when given, only the (incremental) changes to the parent are saved
   # please see store_fixpoint_unless_present for note on why not to use this method
-  def store_fixpoint(fixname, parent_fixname = nil)
+  def store_fixpoint(fixname, parent_fixname = nil, base: ActiveRecord::Base)
     parent_fixname = @last_restored if parent_fixname == :last_restored
-    IncrementalFixpoint.from_database(parent_fixname).save_to_file(fixname)
+    IncrementalFixpoint.from_database(parent_fixname, base.connection).save_to_file(fixname)
   end
 end

--- a/lib/fixpoints/version.rb
+++ b/lib/fixpoints/version.rb
@@ -1,3 +1,3 @@
 module Fixpoints
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/lib/incremental_fixpoint.rb
+++ b/lib/incremental_fixpoint.rb
@@ -33,11 +33,11 @@ class IncrementalFixpoint < Fixpoint
   end
 
   # Creates a Fixpoint from the database contents. Empty tables are skipped.
-  def self.from_database(parent_fixname=nil)
-    return super() if parent_fixname.nil?
+  def self.from_database(parent_fixname=nil, conn)
+    return super(conn) if parent_fixname.nil?
 
     parent = from_file(parent_fixname)
-    changes_in_tables = FixpointDiff.extract_changes(parent.records_in_tables, read_database_records)
+    changes_in_tables = FixpointDiff.extract_changes(parent.records_in_tables, read_database_records(conn))
     new(changes_in_tables, parent_fixname)
   end
 

--- a/spec/fixpoint_spec.rb
+++ b/spec/fixpoint_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe Fixpoint, order: :defined do
 
   it 'raises if there is no fixpoints path' do # this test must come first, so we do not destroy fixpoints...
     FileUtils.rm_rf(fixpoints_path)
-    expect { described_class.from_database.save_to_file('fp_one') }.to raise_error(Fixpoint::Error)
+    expect { described_class.from_database(ActiveRecord::Base.connection).save_to_file('fp_one') }.to raise_error(Fixpoint::Error)
   end
 
   it 'saves and restores fixpoint' do
     Book.create(title: 'Book A')
-    described_class.from_database.save_to_file('fp_one')
+    described_class.from_database(ActiveRecord::Base.connection).save_to_file('fp_one')
 
     # fixpoint contain one entry
     fp = described_class.from_file('fp_one')
@@ -27,17 +27,17 @@ RSpec.describe Fixpoint, order: :defined do
 
     # database should have 1 entry
     Book.delete_all
-    fp.load_into_database
+    fp.load_into_database(ActiveRecord::Base.connection)
     expect(Book.count).to eq(1)
     expect(Book.first.title).to eq('Book A')
   end
 
   describe IncrementalFixpoint do
     it 'stores & restores new record from parent' do
-      described_class.from_file('fp_one').load_into_database
+      described_class.from_file('fp_one').load_into_database(ActiveRecord::Base.connection)
       
       Book.create(title: 'Book B')
-      described_class.from_database('fp_one').save_to_file('fp_two')
+      described_class.from_database('fp_one', ActiveRecord::Base.connection).save_to_file('fp_two')
       
       # fixpoint should contain two entries but the first one empty (because it is incremental)
       fp = described_class.from_file('fp_two')
@@ -45,15 +45,15 @@ RSpec.describe Fixpoint, order: :defined do
       expect(fp.changes_in_tables['books'].first.keys.count).to eq(0)
 
       # database should contain two entries
-      fp.load_into_database
+      fp.load_into_database(ActiveRecord::Base.connection)
       expect(Book.count).to eq(2)
     end
 
     it 'stores & restores updated record' do
-      described_class.from_file('fp_one').load_into_database
+      described_class.from_file('fp_one').load_into_database(ActiveRecord::Base.connection)
 
       Book.find_by(title: 'Book A').update!(summary: 'Lorem and stuff')
-      described_class.from_database('fp_one').save_to_file('fp_tmp')
+      described_class.from_database('fp_one', ActiveRecord::Base.connection).save_to_file('fp_tmp')
       
       # fixpoint should contain one entry, with only one change
       fp = described_class.from_file('fp_tmp')
@@ -61,33 +61,33 @@ RSpec.describe Fixpoint, order: :defined do
       expect(fp.changes_in_tables['books'].first.keys.count).to eq(1)
 
       # attribute in database should have changed
-      fp.load_into_database
+      fp.load_into_database(ActiveRecord::Base.connection)
       expect(Book.first.summary).to eq('Lorem and stuff')
     end
 
     it 'stores & restores deleted record & restores' do
-      described_class.from_file('fp_one').load_into_database
+      described_class.from_file('fp_one').load_into_database(ActiveRecord::Base.connection)
 
       Book.find_by(title: 'Book A').destroy
-      described_class.from_database('fp_one').save_to_file('fp_tmp')
+      described_class.from_database('fp_one', ActiveRecord::Base.connection).save_to_file('fp_tmp')
 
       # fixpoint should contain one (deletion) entry
       fp = described_class.from_file('fp_tmp')
       expect(fp.changes_in_tables['books'].count).to eq(1)
 
       # there should be no record in database
-      fp.load_into_database
+      fp.load_into_database(ActiveRecord::Base.connection)
       expect(Book.count).to eq(0)
     end
 
     it 'loads chained fixpoints' do
-      described_class.from_file('fp_two').load_into_database
+      described_class.from_file('fp_two').load_into_database(ActiveRecord::Base.connection)
 
       Book.create(title: 'Book C')
-      described_class.from_database('fp_two').save_to_file('fp_tmp')
+      described_class.from_database('fp_two', ActiveRecord::Base.connection).save_to_file('fp_tmp')
 
       # there should be three entries
-      described_class.from_file('fp_tmp').load_into_database
+      described_class.from_file('fp_tmp').load_into_database(ActiveRecord::Base.connection)
       expect(Book.count).to eq(3)
     end
   end

--- a/spec/fixpoint_spec.rb
+++ b/spec/fixpoint_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Fixpoint, order: :defined do
   let(:fixpoints_path) { File.join(__dir__, 'fixpoints') }
+  let(:connection) { ActiveRecord::Base.connection }
   
   before(:each) do
     FileUtils.mkdir_p(fixpoints_path)
@@ -14,12 +15,12 @@ RSpec.describe Fixpoint, order: :defined do
 
   it 'raises if there is no fixpoints path' do # this test must come first, so we do not destroy fixpoints...
     FileUtils.rm_rf(fixpoints_path)
-    expect { described_class.from_database(ActiveRecord::Base.connection).save_to_file('fp_one') }.to raise_error(Fixpoint::Error)
+    expect { described_class.from_database(connection).save_to_file('fp_one') }.to raise_error(Fixpoint::Error)
   end
 
   it 'saves and restores fixpoint' do
     Book.create(title: 'Book A')
-    described_class.from_database(ActiveRecord::Base.connection).save_to_file('fp_one')
+    described_class.from_database(connection).save_to_file('fp_one')
 
     # fixpoint contain one entry
     fp = described_class.from_file('fp_one')
@@ -27,17 +28,17 @@ RSpec.describe Fixpoint, order: :defined do
 
     # database should have 1 entry
     Book.delete_all
-    fp.load_into_database(ActiveRecord::Base.connection)
+    fp.load_into_database(connection)
     expect(Book.count).to eq(1)
     expect(Book.first.title).to eq('Book A')
   end
 
   describe IncrementalFixpoint do
     it 'stores & restores new record from parent' do
-      described_class.from_file('fp_one').load_into_database(ActiveRecord::Base.connection)
+      described_class.from_file('fp_one').load_into_database(connection)
       
       Book.create(title: 'Book B')
-      described_class.from_database('fp_one', ActiveRecord::Base.connection).save_to_file('fp_two')
+      described_class.from_database('fp_one', connection).save_to_file('fp_two')
       
       # fixpoint should contain two entries but the first one empty (because it is incremental)
       fp = described_class.from_file('fp_two')
@@ -45,15 +46,15 @@ RSpec.describe Fixpoint, order: :defined do
       expect(fp.changes_in_tables['books'].first.keys.count).to eq(0)
 
       # database should contain two entries
-      fp.load_into_database(ActiveRecord::Base.connection)
+      fp.load_into_database(connection)
       expect(Book.count).to eq(2)
     end
 
     it 'stores & restores updated record' do
-      described_class.from_file('fp_one').load_into_database(ActiveRecord::Base.connection)
+      described_class.from_file('fp_one').load_into_database(connection)
 
       Book.find_by(title: 'Book A').update!(summary: 'Lorem and stuff')
-      described_class.from_database('fp_one', ActiveRecord::Base.connection).save_to_file('fp_tmp')
+      described_class.from_database('fp_one', connection).save_to_file('fp_tmp')
       
       # fixpoint should contain one entry, with only one change
       fp = described_class.from_file('fp_tmp')
@@ -61,33 +62,33 @@ RSpec.describe Fixpoint, order: :defined do
       expect(fp.changes_in_tables['books'].first.keys.count).to eq(1)
 
       # attribute in database should have changed
-      fp.load_into_database(ActiveRecord::Base.connection)
+      fp.load_into_database(connection)
       expect(Book.first.summary).to eq('Lorem and stuff')
     end
 
     it 'stores & restores deleted record & restores' do
-      described_class.from_file('fp_one').load_into_database(ActiveRecord::Base.connection)
+      described_class.from_file('fp_one').load_into_database(connection)
 
       Book.find_by(title: 'Book A').destroy
-      described_class.from_database('fp_one', ActiveRecord::Base.connection).save_to_file('fp_tmp')
+      described_class.from_database('fp_one', connection).save_to_file('fp_tmp')
 
       # fixpoint should contain one (deletion) entry
       fp = described_class.from_file('fp_tmp')
       expect(fp.changes_in_tables['books'].count).to eq(1)
 
       # there should be no record in database
-      fp.load_into_database(ActiveRecord::Base.connection)
+      fp.load_into_database(connection)
       expect(Book.count).to eq(0)
     end
 
     it 'loads chained fixpoints' do
-      described_class.from_file('fp_two').load_into_database(ActiveRecord::Base.connection)
+      described_class.from_file('fp_two').load_into_database(connection)
 
       Book.create(title: 'Book C')
-      described_class.from_database('fp_two', ActiveRecord::Base.connection).save_to_file('fp_tmp')
+      described_class.from_database('fp_two', connection).save_to_file('fp_tmp')
 
       # there should be three entries
-      described_class.from_file('fp_tmp').load_into_database(ActiveRecord::Base.connection)
+      described_class.from_file('fp_tmp').load_into_database(connection)
       expect(Book.count).to eq(3)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "active_record"
 require "fixpoints"
 
 DB_PATH = File.join(__dir__, '../tmp/test.sqlite3')
-Warning[:deprecated] = false # let's get rid of the annoying kwargs deprecation notice in ActiveRecord
+#Warning[:deprecated] = false # let's get rid of the annoying kwargs deprecation notice in ActiveRecord
 
 class Book < ActiveRecord::Base
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "active_record"
 require "fixpoints"
 
 DB_PATH = File.join(__dir__, '../tmp/test.sqlite3')
-#Warning[:deprecated] = false # let's get rid of the annoying kwargs deprecation notice in ActiveRecord
+Warning[:deprecated] = false # let's get rid of the annoying kwargs deprecation notice in ActiveRecord
 
 class Book < ActiveRecord::Base
 end


### PR DESCRIPTION
This PR adds the ability to pass an AR base class to the fix point test helpers to specify a database to be used.