### PR TITLE
Allow for excluding tables when saving fixpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixpoints (0.2.4)
+    fixpoints (0.2.6)
       activerecord (>= 5.0.0)
       rspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixpoints (0.2.3)
+    fixpoints (0.2.4)
       activerecord (>= 5.0.0)
       rspec
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ RSpec.describe 'User Flow', order: :defined do # !!! mind the order here !!!
 
   it 'posts an item' do
     restore_fixpoint :registered_user
-    
+
     user = User.find_by(name: 'Hans')
     visit new_item_path(user)
     fill_in 'Item', with: '...'
@@ -76,7 +76,7 @@ end
 
 **Changes** If you did a lot of changes to a test, you can remove a fixpoint file from its directory.
 It will be recreated when the test producing it runs again.
-Don't forget re-running the tests based on it because their fixpoints might have to change too.  
+Don't forget re-running the tests based on it because their fixpoints might have to change too.
 Example: You need to add something to the database's `seeds.rb`. All subsequent fixpoints are missing the required entry.
 To update all fixpoints, just remove the whole `spec/fixpoints` folder and re-run all tests. Now all fixpoints should be updated.
 Be careful though, don't just remove the fixpoints if you are not sure what is going on.
@@ -119,6 +119,16 @@ to specify the database connection to use.
 ```ruby
   it 'posts an item' do
     restore_fixpoint :registered_user, connection: ActiveRecord::Base.connection
+    # ...
+  end
+```
+
+**Exclude Tables** If a database contains tables that are irrelevant to your tests, you can use the optional `exclude_tables` parameter
+to specify a set of tables to exclude from the fixpoint.
+
+```ruby
+  it 'excludes versions' do
+    restore_fixpoint :registered_user, exclude_tables: ['versions']
     # ...
   end
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ RSpec.describe 'User Flow', order: :defined do # !!! mind the order here !!!
 
   it 'posts an item' do
     restore_fixpoint :registered_user
-
+    
     user = User.find_by(name: 'Hans')
     visit new_item_path(user)
     fill_in 'Item', with: '...'
@@ -76,7 +76,7 @@ end
 
 **Changes** If you did a lot of changes to a test, you can remove a fixpoint file from its directory.
 It will be recreated when the test producing it runs again.
-Don't forget re-running the tests based on it because their fixpoints might have to change too.
+Don't forget re-running the tests based on it because their fixpoints might have to change too.  
 Example: You need to add something to the database's `seeds.rb`. All subsequent fixpoints are missing the required entry.
 To update all fixpoints, just remove the whole `spec/fixpoints` folder and re-run all tests. Now all fixpoints should be updated.
 Be careful though, don't just remove the fixpoints if you are not sure what is going on.
@@ -128,7 +128,7 @@ to specify a set of tables to exclude from the fixpoint.
 
 ```ruby
   it 'excludes versions' do
-    restore_fixpoint :registered_user, exclude_tables: ['versions']
+    store_fixpoint_unless_present :registered_user, exclude_tables: ['versions']
     # ...
   end
 ```

--- a/lib/fixpoint.rb
+++ b/lib/fixpoint.rb
@@ -45,8 +45,8 @@ class Fixpoint
     end
 
     # Creates a Fixpoint from the database contents. Empty tables are skipped.
-    def from_database(conn)
-      new(read_database_records(conn))
+    def from_database(conn, exclude_tables: [])
+      new(read_database_records(conn, exclude_tables: exclude_tables))
     end
 
     def remove(fixname)
@@ -81,11 +81,11 @@ class Fixpoint
       File.join(spec_path, FIXPOINT_FOLDER)
     end
 
-    def read_database_records(conn)
+    def read_database_records(conn, exclude_tables: [])
       # adapted from: https://yizeng.me/2017/07/16/generate-rails-test-fixtures-yaml-from-database-dump/
       tables = conn.tables
-      tables.reject! { |table_name| TABLES_TO_SKIP.include?(table_name) }
-
+      excluded_tables = TABLES_TO_SKIP + exclude_tables
+      tables.reject! { |table_name| excluded_tables.include?(table_name) }
       tables.each_with_object({}) do |table_name, acc|
         result = conn.select_all("SELECT * FROM #{conn.quote_table_name(table_name)}")
         next if result.count.zero?

--- a/lib/fixpoint_test_helpers.rb
+++ b/lib/fixpoint_test_helpers.rb
@@ -10,13 +10,14 @@ module FixpointTestHelpers
   # The latter is useful if the fixpoint was deleted to accommodate changes to it (see example in class description).
   #
   # +tables_to_compare+ can either be +:all+ or a list of table names (e.g. ['users', 'posts'])
+  # +exclude_tables+ a list of tables which should be ignored when storing a fixpoint (e.g. ['versions'])
   # +ignored_columns+ see Fixnum#records_for_table
   # +store_fixpoint_and_fail+ when given and the fixpoint does not already exist, a new fixpoint is created an the test will be marked pending/failed
   # +parent_fixname+ when storing a new fixpoint, use this as parent fixpoint (you can specify `:last_restored` then the last given to restore_fixpoint is used; not thread safe)
   # ---
   # If we refactor this to a gem, we should rely on rspec (e.g. use minitest or move comparison logic to Fixpoint class).
   # Anyhow, we keep it like this for now, because the expectations give much nicer output than the minitest assertions.
-  def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, store_fixpoint_and_fail: false, parent_fixname: nil, connection: default_connection, exclude_tables: [])
+  def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, exclude_tables: [], store_fixpoint_and_fail: false, parent_fixname: nil, connection: default_connection)
     if !IncrementalFixpoint.exists?(fixname)
       if store_fixpoint_and_fail
         store_fixpoint(fixname, parent_fixname, connection: connection, exclude_tables: exclude_tables)

--- a/lib/fixpoint_test_helpers.rb
+++ b/lib/fixpoint_test_helpers.rb
@@ -16,7 +16,7 @@ module FixpointTestHelpers
   # ---
   # If we refactor this to a gem, we should rely on rspec (e.g. use minitest or move comparison logic to Fixpoint class).
   # Anyhow, we keep it like this for now, because the expectations give much nicer output than the minitest assertions.
-  def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, store_fixpoint_and_fail: false, parent_fixname: nil, connection: default_connection)
+  def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, store_fixpoint_and_fail: false, parent_fixname: nil, connection: default_connection, exclude_tables: [])
     if !IncrementalFixpoint.exists?(fixname)
       if store_fixpoint_and_fail
         store_fixpoint(fixname, parent_fixname, connection: connection)
@@ -27,7 +27,7 @@ module FixpointTestHelpers
       end
     end
 
-    database_fp = IncrementalFixpoint.from_database(nil, connection)
+    database_fp = IncrementalFixpoint.from_database(nil, connection, exclude_tables: exclude_tables)
     fixpoint_fp = IncrementalFixpoint.from_file(fixname)
 
     tables_to_compare = (database_fp.table_names + fixpoint_fp.table_names).uniq if tables_to_compare == :all
@@ -48,9 +48,9 @@ module FixpointTestHelpers
 
   # +parent_fixname+ when given, only the (incremental) changes to the parent are saved
   # please see store_fixpoint_unless_present for note on why not to use this method
-  def store_fixpoint(fixname, parent_fixname = nil, connection: default_connection)
+  def store_fixpoint(fixname, parent_fixname = nil, connection: default_connection, exclude_tables: [])
     parent_fixname = @last_restored if parent_fixname == :last_restored
-    IncrementalFixpoint.from_database(parent_fixname, connection).save_to_file(fixname)
+    IncrementalFixpoint.from_database(parent_fixname, connection, exclude_tables: exclude_tables).save_to_file(fixname)
   end
 
   private def default_connection

--- a/lib/fixpoint_test_helpers.rb
+++ b/lib/fixpoint_test_helpers.rb
@@ -19,7 +19,7 @@ module FixpointTestHelpers
   def compare_fixpoint(fixname, ignored_columns=[:updated_at, :created_at], tables_to_compare: :all, store_fixpoint_and_fail: false, parent_fixname: nil, connection: default_connection, exclude_tables: [])
     if !IncrementalFixpoint.exists?(fixname)
       if store_fixpoint_and_fail
-        store_fixpoint(fixname, parent_fixname, connection: connection)
+        store_fixpoint(fixname, parent_fixname, connection: connection, exclude_tables: exclude_tables)
         pending("Fixpoint \"#{fixname}\" did not exist yet. Skipping comparison, but created fixpoint from database. Try re-running the test.")
         fail
       else
@@ -42,8 +42,8 @@ module FixpointTestHelpers
 
   # it is not a good idea to overwrite the fixpoint each time because timestamps may change (which then shows up in version control).
   # Hence we only provide a method to write to it if it does not exist.
-  def store_fixpoint_unless_present(fixname, parent_fixname = nil, connection: default_connection)
-    store_fixpoint(fixname, parent_fixname, connection: connection) unless IncrementalFixpoint.exists?(fixname)
+  def store_fixpoint_unless_present(fixname, parent_fixname = nil, connection: default_connection, exclude_tables: [])
+    store_fixpoint(fixname, parent_fixname, connection: connection, exclude_tables: exclude_tables) unless IncrementalFixpoint.exists?(fixname)
   end
 
   # +parent_fixname+ when given, only the (incremental) changes to the parent are saved

--- a/lib/fixpoints/version.rb
+++ b/lib/fixpoints/version.rb
@@ -1,3 +1,3 @@
 module Fixpoints
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end

--- a/lib/incremental_fixpoint.rb
+++ b/lib/incremental_fixpoint.rb
@@ -33,11 +33,11 @@ class IncrementalFixpoint < Fixpoint
   end
 
   # Creates a Fixpoint from the database contents. Empty tables are skipped.
-  def self.from_database(parent_fixname=nil, conn)
+  def self.from_database(parent_fixname=nil, conn, exclude_tables: [])
     return super(conn) if parent_fixname.nil?
 
     parent = from_file(parent_fixname)
-    changes_in_tables = FixpointDiff.extract_changes(parent.records_in_tables, read_database_records(conn))
+    changes_in_tables = FixpointDiff.extract_changes(parent.records_in_tables, read_database_records(conn, exclude_tables: exclude_tables))
     new(changes_in_tables, parent_fixname)
   end
 

--- a/lib/incremental_fixpoint.rb
+++ b/lib/incremental_fixpoint.rb
@@ -34,7 +34,7 @@ class IncrementalFixpoint < Fixpoint
 
   # Creates a Fixpoint from the database contents. Empty tables are skipped.
   def self.from_database(parent_fixname=nil, conn, exclude_tables: [])
-    return super(conn) if parent_fixname.nil?
+    return super(conn, exclude_tables: exclude_tables) if parent_fixname.nil?
 
     parent = from_file(parent_fixname)
     changes_in_tables = FixpointDiff.extract_changes(parent.records_in_tables, read_database_records(conn, exclude_tables: exclude_tables))

--- a/spec/fixpoint_spec.rb
+++ b/spec/fixpoint_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Fixpoint, order: :defined do
   let(:fixpoints_path) { File.join(__dir__, 'fixpoints') }
   let(:connection) { ActiveRecord::Base.connection }
-  
+
   before(:each) do
     FileUtils.mkdir_p(fixpoints_path)
     Book.delete_all
@@ -20,26 +20,52 @@ RSpec.describe Fixpoint, order: :defined do
 
   it 'saves and restores fixpoint' do
     Book.create(title: 'Book A')
+    Author.create(first_name: 'Faker', last_name: 'Fakerson')
     described_class.from_database(connection).save_to_file('fp_one')
 
-    # fixpoint contain one entry
+    # fixpoint contain one book entry, one author entry
     fp = described_class.from_file('fp_one')
     expect(fp.records_in_tables['books'].count).to eq(1)
+    expect(fp.records_in_tables['authors'].count).to eq(1)
 
     # database should have 1 entry
     Book.delete_all
+    Author.delete_all
     fp.load_into_database(connection)
     expect(Book.count).to eq(1)
     expect(Book.first.title).to eq('Book A')
+    expect(Author.count).to eq(1)
+    expect(Author.first.first_name).to eq('Faker')
+  end
+
+  it 'saves and restores fixpoint ignoring a table' do
+    Book.delete_all
+    Author.delete_all
+    Book.create(title: 'Book A')
+    Author.create(first_name: 'Faker', last_name: 'Fakerson')
+    described_class.from_database(connection, exclude_tables: ['authors']).save_to_file('fp_one')
+
+    # fixpoint contain one book entry, no authors
+    fp = described_class.from_file('fp_one')
+    expect(fp.records_in_tables['books'].count).to eq(1)
+    expect(fp.records_in_tables['authors']).to eq(nil)
+
+    # database should have 1 book entry, no authors
+    Book.delete_all
+    Author.delete_all
+    fp.load_into_database(connection)
+    expect(Book.count).to eq(1)
+    expect(Book.first.title).to eq('Book A')
+    expect(Author.count).to eq(0)
   end
 
   describe IncrementalFixpoint do
     it 'stores & restores new record from parent' do
       described_class.from_file('fp_one').load_into_database(connection)
-      
+
       Book.create(title: 'Book B')
       described_class.from_database('fp_one', connection).save_to_file('fp_two')
-      
+
       # fixpoint should contain two entries but the first one empty (because it is incremental)
       fp = described_class.from_file('fp_two')
       expect(fp.changes_in_tables['books'].count).to eq(2)
@@ -55,7 +81,7 @@ RSpec.describe Fixpoint, order: :defined do
 
       Book.find_by(title: 'Book A').update!(summary: 'Lorem and stuff')
       described_class.from_database('fp_one', connection).save_to_file('fp_tmp')
-      
+
       # fixpoint should contain one entry, with only one change
       fp = described_class.from_file('fp_tmp')
       expect(fp.changes_in_tables['books'].count).to eq(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,8 +30,6 @@ RSpec.configure do |config|
         t.string :summary
         t.timestamps
       end
-    end
-    ActiveRecord::Schema.define do
       create_table :authors do |t|
         t.string :first_name
         t.string :last_name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ Warning[:deprecated] = false # let's get rid of the annoying kwargs deprecation 
 
 class Book < ActiveRecord::Base
 end
+class Author < ActiveRecord::Base
+end
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
@@ -26,6 +28,13 @@ RSpec.configure do |config|
       create_table :books do |t|
         t.string :title
         t.string :summary
+        t.timestamps
+      end
+    end
+    ActiveRecord::Schema.define do
+      create_table :authors do |t|
+        t.string :first_name
+        t.string :last_name
         t.timestamps
       end
     end


### PR DESCRIPTION
This PR allows for excluding a set of tables from a database dump.  This can drastically increase the speed of tests if there are tables that are irrelevant to a set of test, since they won't be stored in the fixpoint and won't be restored to the database on each subsequent load.